### PR TITLE
Merge v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,24 @@
 
 Notable changes are listed below.
 
+## [0.2.0] - 2024-05-19
+
+### Added
+
+- `DictBasedPreference`: A new preference class that can be used to exactly specify the compatibility score for all attribute values. While `CategoricalPreference` class was able to handle value-compatibility dictionaries, `DictBasedPreference` allows setting a default compatibility score for attribute values that are not specified, and its parameters are more intuitive to use with a dictionary.
+- A "getting started" tutorial in the documentation.
+- Missing parameter explanations in the docstrings.
+
+### Changed
+
+- Added deal-breaker consideration for `RankedAgentMatcher`: It is now possible to consider one-sided or two-sided deal-breakers while making recommendations.
+- Other minor code and documentation improvements, typo fixes.
+
+### Developer notes
+
+- scikit-learn was intended to be dropped from the dependencies. However, due to self-written min-max scaling functions not yielding the exact same results with the one imported from scikit-learn, it was decided to keep scikit-learn.
+- `CategoricalPreference` still has the functionality to handle compatibility dictionaries, but this feature may be deprecated in later versions, as there is now a specific class for dictionaries, `DictBasedPreference`.
+
 ## [0.1.0] - 2024-05-02
 
 ### Overview
@@ -10,12 +28,12 @@ Notable changes are listed below.
 
 ### Added
 
-- pyproject.toml file.
+- `pyproject.toml` file.	
 
 ### Changed
 
-- Rename the package to "catfish-sim" for brevity and to align with conventions, as PyPI prefers shorter package names.
+- Renamed the package to "catfish-sim" for brevity and to align with conventions, as PyPI prefers shorter package names.
 
 ### Removed
 
-- `Strategy` subclass `AdaptiveWeightedMinimal` and Optuna dependency: This strategy was written to make the agent adapt its reported preferences based on its past success, but the preliminary results tests suggested it was not working as intended.
+- `Strategy` subclass `AdaptiveWeightedMinimal` and Optuna dependency: This strategy was written to make the agent adapt its reported preferences based on its past success, but the preliminary test results suggested it was not working as intended.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Notable changes are listed below.
 - `DictBasedPreference`: A new preference class that can be used to exactly specify the compatibility score for all attribute values. While `CategoricalPreference` class was able to handle value-compatibility dictionaries, `DictBasedPreference` allows setting a default compatibility score for attribute values that are not specified, and its parameters are more intuitive to use with a dictionary.
 - A "getting started" tutorial in the documentation.
 - Missing parameter explanations in the docstrings.
+- LLCP2022 dataset ranges for age, height, and BMI for ease of use.
 
 ### Changed
 

--- a/catfish_sim/__init__.py
+++ b/catfish_sim/__init__.py
@@ -1,0 +1,3 @@
+import importlib.metadata
+
+__version__ = importlib.metadata.version("catfish_sim")

--- a/catfish_sim/utils.py
+++ b/catfish_sim/utils.py
@@ -4,6 +4,13 @@ import scipy.stats
 import math
 import os
 
+LLCP2022_AGE_GROUP_RANGE = [1, 13]
+LLCP2022_HEIGHT_RANGE = [91, 241]
+LLCP2022_BMI_GROUP_RANGE = [1, 4]
+LLCP2022_DATA = pd.read_csv(
+    os.path.join(os.path.dirname(__file__), "data/LLCP2022_sex_age_height_bmi.csv")
+)
+
 
 def get_random_gender(male_weight=0.72):
     """Samples gender.
@@ -60,7 +67,7 @@ def get_agent_stats(agents):
 
 
 def sample_bmi_from_sex_age(sex, age_group):
-    """Samples a weight group based on the provided sex and age group based on the data. Based on CCLP2022:
+    """Samples a weight group based on the provided sex and age group based on the data. Based on LLCP2022:
     https://www.cdc.gov/brfss/annual_data/annual_2022.html
 
     Args:
@@ -245,7 +252,7 @@ def sample_bmi_from_sex_age(sex, age_group):
 
 
 def sample_age_from_sex(sex, consider_dating_population=True):
-    """Samples age from sex (based on CCLP2022: https://www.cdc.gov/brfss/annual_data/annual_2022.html) and optionally
+    """Samples age from sex (based on LLCP2022: https://www.cdc.gov/brfss/annual_data/annual_2022.html) and optionally
     calibrates the probabilities according to online dating age penetration distribution (based on
     https://www.pewresearch.org/short-reads/2023/02/02/key-findings-about-online-dating-in-the-u-s/).
 
@@ -320,17 +327,14 @@ def sample_age_from_sex(sex, consider_dating_population=True):
     )
 
 
-def sample_height_from_sex_age(
-    sex, age_group, dataset="data/LLCP2022_sex_age_height_bmi.csv"
-):
-    """Samples height from the provided sex and age group (based on CCLP2022:
+def sample_height_from_sex_age(sex, age_group):
+    """Samples height from the provided sex and age group (based on LLCP2022:
     https://www.cdc.gov/brfss/annual_data/annual_2022.html).
 
     Args:
         sex (str): "Male" or "Female."
         age_group (str|int): Age group ID (1: 18-24, 2: 25-29, 3: 30-34, 4: 35-39, 5: 40-44, 6: 45-49, 7: 50-54,
             8: 55-59, 9: 60-64, 10: 65-69, 11: 70-74, 12: 75-79, 13: 80+).
-        dataset (str, optional): LLCP2022 dataset location. Defaults to "../LLCP2022_sex_age_height_bmi.csv".
 
     Returns:
         int: Rounded sampled height.
@@ -341,7 +345,7 @@ def sample_height_from_sex_age(
         sex = 2
     age = int(age_group)
 
-    dataset = pd.read_csv(os.path.join(os.path.dirname(__file__), dataset))
+    dataset = LLCP2022_DATA
 
     kde = scipy.stats.gaussian_kde(
         dataset[
@@ -416,21 +420,18 @@ def sample_age_preference(sex, age_group, allowed_diff=3):
     return preference
 
 
-def get_height_preference(
-    gender, height, dataset="data/LLCP2022_sex_age_height_bmi.csv"
-):
-    """Deterministically obtains a height preference range for a given gender and height.
+def get_height_preference(gender, height):
+    """Deterministically obtains a height preference range for a given gender and height. Uses the height range from
+    LLCP2022 data.
 
     Args:
         gender (str): Agent gender.
         height (int): Agent height.
-        dataset (str, optional): LLCP2022 dataset location. Defaults to "data/LLCP2022_sex_age_height_bmi.csv".
 
     Returns:
         list: Height preference range, as [min, max].
     """
-    dataset = pd.read_csv(os.path.join(os.path.dirname(__file__), dataset))
-    allowed_height_range = [dataset["HTM4"].min(), dataset["HTM4"].max()]
+    allowed_height_range = LLCP2022_HEIGHT_RANGE
 
     if gender == "Male":
         return [

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -8,24 +8,52 @@
 
 import os
 import sys
+import importlib.metadata
+
 
 sys.path.insert(0, os.path.abspath(".."))
 
 project = "catfish-sim"
-copyright = "2024, Oz Kilic"
+copyright = "2024, catfish-sim developers"
 author = "Oz Kilic"
-release = "0.1.1"
+release = importlib.metadata.version("catfish_sim")
+
 
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration
 
 extensions = [
+    # "myst_parser",
+    # "myst_nb",
+    "sphinx.ext.autodoc",
+    "sphinx.ext.intersphinx",
     "sphinx.ext.napoleon",
     "sphinx_rtd_theme",
     "sphinx.ext.todo",
     "sphinx.ext.viewcode",
-    "sphinx.ext.autodoc",
+    # "sphinx.ext.autosectionlabel",
+    "nbsphinx",
+    "IPython.sphinxext.ipython_console_highlighting",
 ]
+
+# nbsphinx_allow_errors = True
+# nbsphinx_execute = "always"
+# myst_enable_extensions = ["colon_fence"]
+myst_all_links_external = True
+# source_suffix = [
+#     ".rst",
+#     ".md",
+# ]
+
+pygments_style = "sphinx"
+
+intersphinx_mapping = {
+    "python": ("https://docs.python.org/3", None),
+    "catfish_sim": (
+        "https://catfish-sim.readthedocs.io/en/latest/",
+        None,
+    ),
+}
 
 templates_path = ["_templates"]
 exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]

--- a/docs/examples/getting_started.ipynb
+++ b/docs/examples/getting_started.ipynb
@@ -1,0 +1,904 @@
+{
+    "cells": [
+        {
+            "cell_type": "markdown",
+            "id": "6cbb4a94",
+            "metadata": {},
+            "source": [
+                "# Getting started with catfish-sim"
+            ]
+        },
+        {
+            "cell_type": "markdown",
+            "id": "e4b4dac7-8528-46e9-9015-4adeba822641",
+            "metadata": {},
+            "source": [
+                "Written using version `0.2.0`.\n",
+                "\n",
+                "In this bottom-up tutorial, you will learn the basics of catfish-sim to simulate an online dating environment.\n",
+                "\n",
+                "You can install the package using `pip install catfish-sim`."
+            ]
+        },
+        {
+            "cell_type": "markdown",
+            "id": "93faf28a",
+            "metadata": {},
+            "source": [
+                "## Creating an agent"
+            ]
+        },
+        {
+            "cell_type": "markdown",
+            "id": "07eac5d5",
+            "metadata": {},
+            "source": [
+                "Before we create an agent, we need to understand preference, attribute, and strategy concepts, which constitute a significant portion of agents."
+            ]
+        },
+        {
+            "cell_type": "markdown",
+            "id": "a9f25a2b",
+            "metadata": {},
+            "source": [
+                "### Preference"
+            ]
+        },
+        {
+            "cell_type": "markdown",
+            "id": "b576f134",
+            "metadata": {},
+            "source": [
+                "In catfish-sim, agents have preference objects that define the attribute-specific preference of an agent. Depending on how the relevant attribute is used, different preference classes can be used. For categorical attributes, an example [CategoricalPreference](../catfish_sim.html#catfish_sim.compatibility.CategoricalPreference) object is shown below:"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": 1,
+            "id": "1ab141df-24df-4427-b239-80e159090ca2",
+            "metadata": {},
+            "outputs": [
+                {
+                    "name": "stdout",
+                    "output_type": "stream",
+                    "text": [
+                        "CategoricalPreference(\n",
+                        "\tpreferred_values=['a', 'b'], \n",
+                        "\tpreferred_score=1.25, \n",
+                        "\tnonpreferred_score=0.75\n",
+                        ")\n"
+                    ]
+                }
+            ],
+            "source": [
+                "from catfish_sim.compatibility import CategoricalPreference\n",
+                "\n",
+                "cat_pref = CategoricalPreference(\n",
+                "    preferred_values=[\"a\", \"b\"],\n",
+                "    allowed_values=[\"a\", \"b\", \"c\", \"d\"],\n",
+                "    preferred_score=1.25,\n",
+                "    nonpreferred_score=0.75,\n",
+                "    compatibility_weight=1,\n",
+                ")\n",
+                "\n",
+                "print(cat_pref)"
+            ]
+        },
+        {
+            "cell_type": "markdown",
+            "id": "5af2d6be-cf78-4ef7-a7c8-f7aacc5dff1a",
+            "metadata": {},
+            "source": [
+                "This preference suggests that the agent that carries it obtains an attribute-specific compatibility score of $1.25$ (`preferred_score`) when their candidate's attribute value is \"a\" or \"b\", because \"a\" and \"b\" are stated to be preferred. For other values, the compatibility score is $0.75$ (`nonpreferred_score`). We can see these compatibilities by calling `evaluate_attribute` with the attribute value that will be judged by the preference."
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": 2,
+            "id": "1f25c688-17c8-4b24-8dec-c5a4ca98274e",
+            "metadata": {},
+            "outputs": [
+                {
+                    "name": "stdout",
+                    "output_type": "stream",
+                    "text": [
+                        "Compatibility with a: 1.25\n",
+                        "Compatibility with c: 0.75\n"
+                    ]
+                }
+            ],
+            "source": [
+                "print(\"Compatibility with a:\", cat_pref.evaluate_attribute(\"a\"))\n",
+                "print(\"Compatibility with c:\", cat_pref.evaluate_attribute(\"c\"))"
+            ]
+        },
+        {
+            "cell_type": "markdown",
+            "id": "ce8a7eeb-306e-4e54-a648-96979fa05b04",
+            "metadata": {},
+            "source": [
+                "Note that categories do not need to be strings. For example, you could have other types, such as boolean or integer, that can be compared with the candidate's attribute.\n",
+                "\n",
+                "For numerical attributes where the agent has a continuous preference range, an example [NumericalPreference](../catfish_sim.html#catfish_sim.compatibility.NumericalPreference) object is shown below:"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": 3,
+            "id": "6a95eabc-aa34-4ac2-9870-65586d0b96a4",
+            "metadata": {},
+            "outputs": [
+                {
+                    "name": "stdout",
+                    "output_type": "stream",
+                    "text": [
+                        "NumericalPreference(\n",
+                        "\tpreferred_range=[2, 4], \n",
+                        "\tpreferred_score=1.25, \n",
+                        "\tnonpreferred_score=0.75, \n",
+                        "\tdistance_sensitive=False, \n",
+                        "\tcompatibility_weight=1, \n",
+                        "\tcompatibility_fn=None\n",
+                        ")\n"
+                    ]
+                }
+            ],
+            "source": [
+                "from catfish_sim.compatibility import NumericalPreference\n",
+                "\n",
+                "num_pref = NumericalPreference(\n",
+                "    preferred_range=[2, 4],\n",
+                "    allowed_range=[1, 10],\n",
+                "    preferred_score=1.25,\n",
+                "    nonpreferred_score=0.75,\n",
+                "    distance_sensitive=False,\n",
+                "    compatibility_weight=1,\n",
+                "    compatibility_fn=None,\n",
+                ")\n",
+                "\n",
+                "print(num_pref)"
+            ]
+        },
+        {
+            "cell_type": "markdown",
+            "id": "f4beab4b",
+            "metadata": {},
+            "source": [
+                "Since `distance_sensitive` is set to `False`, the preference here denotes that a value between 2 and 4 yields a compatibility score of $1.25$, while anything outside this range yields $0.75$:\n"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": 4,
+            "id": "9fab3fd1",
+            "metadata": {},
+            "outputs": [
+                {
+                    "name": "stdout",
+                    "output_type": "stream",
+                    "text": [
+                        "1.25\n",
+                        "0.75\n"
+                    ]
+                }
+            ],
+            "source": [
+                "print(num_pref.evaluate_attribute(2.5))\n",
+                "print(num_pref.evaluate_attribute(1.5))"
+            ]
+        },
+        {
+            "cell_type": "markdown",
+            "id": "9e1f678d",
+            "metadata": {},
+            "source": [
+                "It is possible to have a distance-sensitive evaluation where the compatibility score is mapped to a value between `nonpreferred_score` and $1$ based on the difference between the evaluated value and the closest preferred value:"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": 5,
+            "id": "4270a9da",
+            "metadata": {},
+            "outputs": [
+                {
+                    "name": "stdout",
+                    "output_type": "stream",
+                    "text": [
+                        "NumericalPreference(\n",
+                        "\tpreferred_range=[2, 4], \n",
+                        "\tpreferred_score=1.25, \n",
+                        "\tnonpreferred_score=0.75, \n",
+                        "\tdistance_sensitive=True, \n",
+                        "\tcompatibility_weight=1, \n",
+                        "\tcompatibility_fn=<function Preference.__init__.<locals>.<lambda> at 0x000001E0F4BAB640>\n",
+                        ")\n",
+                        "1.25\n",
+                        "0.9861111111111112\n",
+                        "0.8333333333333334\n"
+                    ]
+                }
+            ],
+            "source": [
+                "num_pref = NumericalPreference(\n",
+                "    preferred_range=[2, 4],\n",
+                "    allowed_range=[1, 10],\n",
+                "    preferred_score=1.25,\n",
+                "    nonpreferred_score=0.75,\n",
+                "    distance_sensitive=True,  # Distance-sensitive calculation.\n",
+                "    compatibility_weight=1,\n",
+                "    compatibility_fn=None,  # None makes the preference use the default scaling.\n",
+                ")\n",
+                "\n",
+                "print(num_pref)\n",
+                "print(num_pref.evaluate_attribute(2.5))\n",
+                "print(num_pref.evaluate_attribute(1.5))\n",
+                "print(num_pref.evaluate_attribute(10))"
+            ]
+        },
+        {
+            "cell_type": "markdown",
+            "id": "b0cdac5d",
+            "metadata": {},
+            "source": [
+                "Here we see that the difference between $1.5$ and its closest preferred value ($2$) is smaller than the difference between $10$ and its closest preferred value ($4$), so it yields a higher compatibility score. It is possible to pass a custom function as the `compatibility_fn` that takes the evaluated value to specify how compatibility is calculated.\n",
+                "\n",
+                "If you need to manually specify many different compatibility scores for different attribute values, you can use [DictBasedPreference](../catfish_sim.html#catfish_sim.compatibility.DictBasedPreference) which directly uses the provided dictionary."
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": 6,
+            "id": "2ee9af49",
+            "metadata": {},
+            "outputs": [
+                {
+                    "name": "stdout",
+                    "output_type": "stream",
+                    "text": [
+                        "DictPreference(\n",
+                        "\tcompatibility_dict={'a': 1.25, 'b': 1, 'c': 0.9, 'd': 0.75}, \n",
+                        "\tdefault_value=1, \n",
+                        "\tcompatibility_weight=1)\n",
+                        "0.9\n",
+                        "1\n"
+                    ]
+                }
+            ],
+            "source": [
+                "from catfish_sim.compatibility import DictBasedPreference\n",
+                "\n",
+                "dict_pref = DictBasedPreference(\n",
+                "    compatibility_dict={\"a\": 1.25, \"b\": 1, \"c\": 0.9, \"d\": 0.75},\n",
+                "    default_value=1,\n",
+                "    compatibility_weight=1,\n",
+                ")\n",
+                "\n",
+                "print(dict_pref)\n",
+                "print(dict_pref.evaluate_attribute(\"c\"))\n",
+                "print(\n",
+                "    dict_pref.evaluate_attribute(\"e\")\n",
+                ")  # e is not included in the dictionary, so the default value is returned."
+            ]
+        },
+        {
+            "cell_type": "markdown",
+            "id": "b412ffab-e142-4307-964f-4f3ec38e13db",
+            "metadata": {},
+            "source": [
+                "`compatibility_weight` of a preference is used to calculate the overall compatibility score for a given candidate using the weighted average of all attribute compatibilities. This allows a preference that is more important for the agent to be more dominant over the less important ones.\n",
+                "\n",
+                "In our model, preference is modeled as a multiplier that can enhance or diminish the effect of the candidate's attractiveness. For this reason, a full compatibility is considered to have a value of 1.25 while a total incompatibility is considered to have a value of 0.75. However, you may want to have a different calculation and therefore compatibility values.\n",
+                "\n",
+                "You can write a custom preference class and implement the `evaluate_attribute` method that takes the candidate value and returns the compatibility score.\n",
+                "\n",
+                "For definite deal-breakers, `-math.inf` value can be used as the compatibility score. This is especially useful to prevent making impossible recommendations where the candidate would not like the judging agent. An example case is shown below (additional information is given under matchers):"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": 7,
+            "id": "b78215d2",
+            "metadata": {},
+            "outputs": [
+                {
+                    "data": {
+                        "text/plain": [
+                            "CategoricalPreference(\n",
+                            "\tpreferred_values=['Female'], \n",
+                            "\tpreferred_score=1, \n",
+                            "\tnonpreferred_score=-inf\n",
+                            ")"
+                        ]
+                    },
+                    "execution_count": 7,
+                    "metadata": {},
+                    "output_type": "execute_result"
+                }
+            ],
+            "source": [
+                "import math\n",
+                "\n",
+                "CategoricalPreference(\n",
+                "    preferred_values=[\"Female\"],\n",
+                "    allowed_values=[\"Male\", \"Female\"],\n",
+                "    preferred_score=1,\n",
+                "    nonpreferred_score=-math.inf,  # Absolutely does not want any non-femmale candidate.\n",
+                ")"
+            ]
+        },
+        {
+            "cell_type": "markdown",
+            "id": "c2a38f9c",
+            "metadata": {},
+            "source": [
+                "### Attribute"
+            ]
+        },
+        {
+            "cell_type": "markdown",
+            "id": "710bc2af",
+            "metadata": {},
+            "source": [
+                "Agents can have an arbitrary amount of attributes that are used to calculate the compatibility. An [Attribute](../catfish_sim.html#catfish_sim.compatibility.Attribute) object has an attribute name, attribute value, and a [Preference](../catfish_sim.html#catfish_sim.compatibility.Preference) object that is tied to that attribute. For example, a heterosexual male agent who only prefers female candidates can be set to have the following gender attribute:"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": 8,
+            "id": "dc7a819d",
+            "metadata": {},
+            "outputs": [
+                {
+                    "name": "stdout",
+                    "output_type": "stream",
+                    "text": [
+                        "Attribute(name=Gender, value=Male, preference=CategoricalPreference(\n",
+                        "\tpreferred_values=['Female'], \n",
+                        "\tpreferred_score=1, \n",
+                        "\tnonpreferred_score=-inf\n",
+                        "))\n"
+                    ]
+                }
+            ],
+            "source": [
+                "from catfish_sim.compatibility import Attribute\n",
+                "\n",
+                "gender_attr = Attribute(\n",
+                "    name=\"Gender\",\n",
+                "    value=\"Male\",\n",
+                "    preference=CategoricalPreference(\n",
+                "        preferred_values=[\"Female\"],\n",
+                "        allowed_values=[\"Male\", \"Female\"],\n",
+                "        preferred_score=1,\n",
+                "        nonpreferred_score=-math.inf,\n",
+                "        compatibility_weight=1,\n",
+                "    ),\n",
+                ")\n",
+                "\n",
+                "print(gender_attr)"
+            ]
+        },
+        {
+            "cell_type": "markdown",
+            "id": "6adb1bd9",
+            "metadata": {},
+            "source": [
+                "An important detail is that each agent must have a gender attribute which affects various things such as how their attributes are sampled or how they derive utility."
+            ]
+        },
+        {
+            "cell_type": "markdown",
+            "id": "d2724d7a",
+            "metadata": {},
+            "source": [
+                "### Strategy"
+            ]
+        },
+        {
+            "cell_type": "markdown",
+            "id": "ab6b3876",
+            "metadata": {},
+            "source": [
+                "A strategy object is used by an agent to like or pass a candidate. Currently, the following strategy classes that extend the base [Strategy](../catfish_sim.html#catfish_sim.strategies.Strategy) class exist:\n",
+                "*   [WeightedMinimal](../catfish_sim.html#catfish_sim.strategies.WeightedMinimal): Likes a candidate if the multiplication of the candidate's attractiveness and overall (weighted average) compatibility is equal or greater than the agent's estimated attractiveness.\n",
+                "*   [Adventurous](../catfish_sim.html#catfish_sim.strategies.Adventurous): Randomly likes or passes the candidate.\n",
+                "*   [PhysicalHomophiliac](../catfish_sim.html#catfish_sim.strategies.PhysicalHomophiliac): Likes a candidate if their attractiveness within the specified range of their own estimated attractiveness.\n",
+                "*   [SocialClimber](../catfish_sim.html#catfish_sim.strategies.SocialClimber): Likes a candidate whose attractiveness is greater than the agent's own estimated attractiveness.\n",
+                "\n",
+                "You can check the documentation for details and write your own strategy class as well. Note that all strategy classes extend the base `Strategy` class and implement the following methods:\n",
+                "*   `is_interested`: This method decides whether an agent will like the candidate.\n",
+                "*   `match_hook`: This hook function is called when there is a match. \n",
+                "*   `new_round_hook`: This hook function is called when a new round starts.\n",
+                "\n",
+                "The hook functions are optional and can be used by strategies that can make use of additional information.\n",
+                "\n",
+                "Let us create a `WeightedMinimal` strategy object:"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": 9,
+            "id": "3523c6c7",
+            "metadata": {},
+            "outputs": [],
+            "source": [
+                "from catfish_sim.strategies import WeightedMinimal\n",
+                "\n",
+                "strat = WeightedMinimal()"
+            ]
+        },
+        {
+            "cell_type": "markdown",
+            "id": "1469a5e6",
+            "metadata": {},
+            "source": [
+                "Note that these strategies cannot function without an agent object, as agents pass their information to the `is_interested` method of their strategy object."
+            ]
+        },
+        {
+            "cell_type": "markdown",
+            "id": "f7f4b0fb",
+            "metadata": {},
+            "source": [
+                "### Agent"
+            ]
+        },
+        {
+            "cell_type": "markdown",
+            "id": "c71a363a",
+            "metadata": {},
+            "source": [
+                "Now that we know how to create preference, attribute, and strategy objects, we can create an [Agent](../catfish_sim.html#catfish_sim.agents.Agent) object. Each agent represents an online dating user in catfish-sim, and has the following attributes:\n",
+                "\n",
+                "*   `reported_attributes`: A dictionary of `Attribute` objects. These attributes can be seen by the matchmaking algorithm and other agents. Reported attributes' preference objects are reported preferences.\n",
+                "*   `hidden_attributes`: A dictionary of `Attribute` objects. These attributes are only known to the agent itself. They ultimately override the reported ones (for example, when evaluating a candidate or calculating utility). Since hidden attributes' preferences are also hidden, they can be also used to make agent have hidden preferences for candidate evaluation purposes. Even if all attributes and preferences of the agent are truthfully reported, `hidden_attributes` must be still used, as attribute-related matters are handled through hidden attributes that are guaranteed to be truthful.\n",
+                "*   `like_allowance`: Liking budget that limits the amount of candidates an agent can like in a round. With each new round, their allowance resets to this value.\n",
+                "*   `strategey`: A `Strategy` object that is used to evaluate a candidate. \n",
+                "*   `compatibility_calculator`: A `CompatibilityCalculator` object that is used to evaluate the weighted average compatibility of a candidate. You will most likely use the default class rather than writing your own.\n",
+                "*   `attractiveness`: Average perceived attractiveness of the agent, between 1.0 and 5.0, known to every other agent but the agent itself. If `None`, this value is sampled based on the agent's gender attribute in `hidden_attributes`. \n",
+                "*   `estimated_attractiveness`: The self-estimated attractiveness of the agent between 1.0 and 5.0. The agent uses this value to make decisions. If `None`, this value is sampled based on the agent's `attractiveness` attribute.\n",
+                "\n",
+                "Let us create our first agent who:\n",
+                "*   Is a 30-year-old female with a height of 165cm.\n",
+                "*   Strictly prefers males. \n",
+                "*   Prefers their candidates who are between 175 and 190 cm. This is the most important attribute in their evaluation.\n",
+                "*   Prefers their candidates who are between 28 and 45 years old. This is the least important attribute in their evaluation.\n",
+                "*   Uses the `WeightedMinimal` strategy.\n",
+                "*   Can like 100 agents per round."
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": 10,
+            "id": "d1700ffa",
+            "metadata": {},
+            "outputs": [],
+            "source": [
+                "from catfish_sim.agents import Agent\n",
+                "from catfish_sim.compatibility import CompatibilityCalculator\n",
+                "from catfish_sim.strategies import WeightedMinimal\n",
+                "import copy\n",
+                "\n",
+                "attributes = {\n",
+                "    \"Gender\": Attribute(\n",
+                "        name=\"Gender\",\n",
+                "        value=\"Female\",  # Agent's gender\n",
+                "        preference=CategoricalPreference(\n",
+                "            preferred_values=[\"Male\"],\n",
+                "            allowed_values=[\"Male\", \"Female\"],\n",
+                "            preferred_score=1,\n",
+                "            nonpreferred_score=-math.inf,\n",
+                "            compatibility_weight=1,\n",
+                "        ),\n",
+                "    ),\n",
+                "    \"Age\": Attribute(\n",
+                "        name=\"Age\",\n",
+                "        value=30,  # Agent's age\n",
+                "        preference=NumericalPreference(\n",
+                "            preferred_range=[28, 45],\n",
+                "            allowed_range=[18, 100],  # Depends on your/modeled population's range.\n",
+                "            preferred_score=1.25,\n",
+                "            nonpreferred_score=0.75,\n",
+                "            distance_sensitive=True,\n",
+                "            compatibility_weight=0.5,  # Less important.\n",
+                "        ),\n",
+                "    ),\n",
+                "    \"Height\": Attribute(\n",
+                "        name=\"Height\",\n",
+                "        value=165,  # Agent's height\n",
+                "        preference=NumericalPreference(\n",
+                "            preferred_range=[175, 190],\n",
+                "            allowed_range=[110, 250],  # Depends on your/modeled population's range.\n",
+                "            preferred_score=1.25,\n",
+                "            nonpreferred_score=0.75,\n",
+                "            distance_sensitive=True,\n",
+                "            compatibility_weight=1.5,  # More important.\n",
+                "        ),\n",
+                "    ),\n",
+                "}\n",
+                "\n",
+                "an_agent = Agent(\n",
+                "    id=0,\n",
+                "    reported_attributes=attributes,\n",
+                "    hidden_attributes=copy.deepcopy(attributes),  # The agent is truthful.\n",
+                "    like_allowance=100,\n",
+                "    strategy=WeightedMinimal(),\n",
+                "    compatibility_calculator=CompatibilityCalculator(),\n",
+                "    attractiveness=None,  # Automatically sampled based on gender.\n",
+                "    estimated_attractiveness=None,  # Automatically sampled based on attractiveness.\n",
+                ")"
+            ]
+        },
+        {
+            "cell_type": "markdown",
+            "id": "1f622e7f",
+            "metadata": {},
+            "source": [
+                "### Sampling a population"
+            ]
+        },
+        {
+            "cell_type": "markdown",
+            "id": "2b3396af",
+            "metadata": {},
+            "source": [
+                "You may want to sample an entire population of agents rather than specifying attributes and preferences. In that case, you can use the provided helper functions, which work based population data and our methods explained in our [study](https://dl.acm.org/doi/10.5555/3635637.3662956). You can read our paper and utility functions' documentation for more information.\n",
+                "\n",
+                "Let us create 1000 agents with gender, age, height, and body-mass index (BMI) attributes. You can use the following code block as a starting point and make changes as you like."
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": 11,
+            "id": "d4c2abbe",
+            "metadata": {},
+            "outputs": [],
+            "source": [
+                "from catfish_sim import utils\n",
+                "\n",
+                "\n",
+                "def create_random_agent(agent_id, like_allowance):\n",
+                "    # Based on gender distribution on Tinder.\n",
+                "    gender = utils.get_random_gender()\n",
+                "\n",
+                "    # Based on LLCP2022 dataset, we used age group IDs (1: 18-24, 2: 25-29, 3: 30-34,\n",
+                "    # 4: 35-39, 5: 40-44, 6: 45-49, 7: 50-54, 8: 55-59, 9: 60-64, 10: 65-69, 11: 70-74,\n",
+                "    # 12: 75-79, 13: 80+) as ordinal age values.\n",
+                "    age = utils.sample_age_from_sex(gender)\n",
+                "    preferred_age_range = utils.sample_age_preference(gender, age)\n",
+                "\n",
+                "    # We rounded height values for easier analysis.\n",
+                "    height = round(utils.sample_height_from_sex_age(gender, age))\n",
+                "    preferred_height_range = utils.get_height_preference(gender, height)\n",
+                "\n",
+                "    # Based on LLCP2022 dataset, we used BMI group IDs (1: Underweight, 2: Normal\n",
+                "    # weight, 3: Overweight, 4: Obesity) as ordinal values.\n",
+                "    bmi = utils.sample_bmi_from_sex_age(gender, age)\n",
+                "    preferred_bmi_range = utils.get_bmi_preference(gender, bmi)\n",
+                "\n",
+                "    # You can use different compatibility weights based on the gender as follows (or\n",
+                "    # completely randomize it).\n",
+                "    if gender == \"Male\":\n",
+                "        # Males care more about weight compatibility\n",
+                "        weight_preferred_score = 1.25\n",
+                "        weight_importance = 1.5\n",
+                "        height_preferred_score = 1.25\n",
+                "        height_importance = 1\n",
+                "        age_preferred_score = 1.25\n",
+                "        age_importance = 1\n",
+                "    else:  # Female\n",
+                "        # Females care more about height compatibility\n",
+                "        weight_preferred_score = 1.25\n",
+                "        weight_importance = 1\n",
+                "        height_preferred_score = 1.25\n",
+                "        height_importance = 1.5\n",
+                "        age_preferred_score = 1.25\n",
+                "        age_importance = 1\n",
+                "\n",
+                "    reported_attributes = {\n",
+                "        \"Gender\": Attribute(\n",
+                "            name=\"Gender\",\n",
+                "            value=gender,\n",
+                "            preference=CategoricalPreference(\n",
+                "                preferred_values=[(\"Female\" if gender == \"Male\" else \"Male\")],\n",
+                "                allowed_values=[\"Male\", \"Female\"],\n",
+                "                preferred_score=1,\n",
+                "                nonpreferred_score=-math.inf,\n",
+                "            ),\n",
+                "        ),\n",
+                "        \"Age\": Attribute(\n",
+                "            name=\"Age\",\n",
+                "            value=age,\n",
+                "            preference=NumericalPreference(\n",
+                "                preferred_range=preferred_age_range,\n",
+                "                allowed_range=utils.LLCP2022_AGE_GROUP_RANGE,  # Based on LLCP2022.\n",
+                "                preferred_score=age_preferred_score,\n",
+                "                nonpreferred_score=0.25,\n",
+                "                distance_sensitive=True,\n",
+                "                compatibility_weight=age_importance,\n",
+                "            ),\n",
+                "        ),\n",
+                "        \"Height\": Attribute(\n",
+                "            name=\"Height\",\n",
+                "            value=height,\n",
+                "            preference=NumericalPreference(\n",
+                "                preferred_range=preferred_height_range,\n",
+                "                allowed_range=utils.LLCP2022_HEIGHT_RANGE,  # Based on LLCP2022.\n",
+                "                preferred_score=height_preferred_score,\n",
+                "                nonpreferred_score=0.25,\n",
+                "                distance_sensitive=True,\n",
+                "                compatibility_weight=height_importance,\n",
+                "            ),\n",
+                "        ),\n",
+                "        \"BMI\": Attribute(\n",
+                "            name=\"BMI\",\n",
+                "            value=bmi,\n",
+                "            preference=NumericalPreference(\n",
+                "                preferred_range=preferred_bmi_range,\n",
+                "                allowed_range=utils.LLCP2022_BMI_GROUP_RANGE,  # Based on LLCP2022.\n",
+                "                preferred_score=weight_preferred_score,\n",
+                "                nonpreferred_score=0.25,\n",
+                "                distance_sensitive=True,\n",
+                "                compatibility_weight=weight_importance,\n",
+                "            ),\n",
+                "        ),\n",
+                "    }\n",
+                "\n",
+                "    hidden_attributes = copy.deepcopy(reported_attributes)\n",
+                "\n",
+                "    agent = Agent(\n",
+                "        id=agent_id,\n",
+                "        reported_attributes=reported_attributes,\n",
+                "        hidden_attributes=hidden_attributes,\n",
+                "        like_allowance=like_allowance,\n",
+                "        strategy=WeightedMinimal(),\n",
+                "        compatibility_calculator=CompatibilityCalculator(),\n",
+                "    )\n",
+                "\n",
+                "    return agent\n",
+                "\n",
+                "\n",
+                "n_agents = 1000\n",
+                "like_allowance = 100\n",
+                "dating_agents = [None] * n_agents\n",
+                "\n",
+                "for i in range(n_agents):\n",
+                "    # Note that agent IDs must correspond to their IDs in the agent list.\n",
+                "    agent = create_random_agent(agent_id=i, like_allowance=like_allowance)\n",
+                "    dating_agents[i] = agent"
+            ]
+        },
+        {
+            "cell_type": "markdown",
+            "id": "85b049c5",
+            "metadata": {},
+            "source": [
+                "## Matchmaking"
+            ]
+        },
+        {
+            "cell_type": "markdown",
+            "id": "7aea4479",
+            "metadata": {},
+            "source": [
+                "### Matcher"
+            ]
+        },
+        {
+            "cell_type": "markdown",
+            "id": "b37e506b",
+            "metadata": {},
+            "source": [
+                "Now that we have our agents ready, we can create the matchmaking system (also referred to as \"matcher\") that will recommend agents to each other. There are different kinds of matchers:\n",
+                "*   [RandomAgentMatcher](../catfish_sim.html#catfish_sim.matchers.RandomAgentMatcher): Makes random recommendations.\n",
+                "*   [PreferentialAgentMatcher](../catfish_sim.html#catfish_sim.matchers.PreferentialAgentMatcher): Sorts and recommends agents based on their compatibility, which is calculated using reported attributes and preferences.\n",
+                "*   [RankedAgentMatcher](../catfish_sim.html#catfish_sim.matchers.RankedAgentMatcher): Uses an Elo-like rating system based on agents being liked/passed by other agents and make recommendations based on ratings.\n",
+                "\n",
+                "Different matchers have different parameters and additional details that are not mentioned here. Please check the documentation for more information.\n",
+                "\n",
+                "Let us create a `PreferentialAgentMatcher` object with the agent population we have just created:"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": 12,
+            "id": "0f1847f1",
+            "metadata": {},
+            "outputs": [],
+            "source": [
+                "from catfish_sim.matchers import PreferentialAgentMatcher\n",
+                "\n",
+                "matcher = PreferentialAgentMatcher(\n",
+                "    agents=dating_agents,\n",
+                "    recommendation_limit=200,  # See below for more information.\n",
+                "    compatibility_calculator=CompatibilityCalculator(),\n",
+                "    judger_weight=0.99,  # See below for more information.\n",
+                "    logging=True,  # This logs agent states after each round ends.\n",
+                "    recalculate=False,  # See below for more information.\n",
+                ")"
+            ]
+        },
+        {
+            "cell_type": "markdown",
+            "id": "2034cc80",
+            "metadata": {},
+            "source": [
+                "This matcher's `recommendation_limit` is set to 200, which means each agent is provided 200 candidates at maximum for every round. `recommendation_limit` should be equal or greater than the agent's `like_allowance`. Otherwise, agents cannot properly use their like budget.\n",
+                "\n",
+                "`judger_weight` is used to calculate the weighted average compatibility between two agents. If it is set to $1$, the compatibility-based sorting only considers the judging agent who evaluates the candidates. Otherwise, the evaluated candidates' perspectives are also considered with a weight of `1 - judger_weight`. Using a `judger_weight` value smaller than $1$ is useful to prevent impossible recommendations where the judged agent is already known to have a deal-breaker which would prevent being matched with the judging agent. For example, a *reportedly* heterosexual male with a `-math.inf` compatibility value for male candidates would never be shown to a homosexual male agent although the juding agent (homosexual male) could like the candidate.\n",
+                "\n",
+                "`recalculate` toggles recalculating preferences and therefore recommendation priorities. It must be set to True if agents can change their attributes or preferences during simulation. However, this is computationally expensive. If when agents change their attributes/preference is known and they do not change it every round, setting this to False and calling `PreferentialAgentMatcher.generate_recommendation_priorities()` before the recommendations is a better approach."
+            ]
+        },
+        {
+            "cell_type": "markdown",
+            "id": "9870a40f",
+            "metadata": {},
+            "source": [
+                "### Running a simulation"
+            ]
+        },
+        {
+            "cell_type": "markdown",
+            "id": "037a9b90",
+            "metadata": {},
+            "source": [
+                "We can now run our simulation in a loop:"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": 13,
+            "id": "8a477a89-971e-4806-bb50-d43a689c8d96",
+            "metadata": {},
+            "outputs": [],
+            "source": [
+                "n_rounds = 10\n",
+                "\n",
+                "for i in range(n_rounds):  # You can use the tqdm package here to track the progress.\n",
+                "    matcher.run_new_round()"
+            ]
+        },
+        {
+            "cell_type": "markdown",
+            "id": "2b429bf9-62c5-4dd7-9f64-16f16e50d589",
+            "metadata": {},
+            "source": [
+                "Once your simulation is complete (or during the simulation), you can retrieve agent objects' attributes either using your agent list or `matcher.agents`. Let us retrieve them for an agent:"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": 14,
+            "id": "882b8a61-ab97-4fd9-98cf-b2f7ce4fe147",
+            "metadata": {},
+            "outputs": [
+                {
+                    "name": "stdout",
+                    "output_type": "stream",
+                    "text": [
+                        "Agent's reported attributes: {'Gender': Attribute(name=Gender, value=Female, preference=CategoricalPreference(\n",
+                        "\tpreferred_values=['Male'], \n",
+                        "\tpreferred_score=1, \n",
+                        "\tnonpreferred_score=-inf\n",
+                        ")), 'Age': Attribute(name=Age, value=5, preference=NumericalPreference(\n",
+                        "\tpreferred_range=[4, 6], \n",
+                        "\tpreferred_score=1.25, \n",
+                        "\tnonpreferred_score=0.25, \n",
+                        "\tdistance_sensitive=True, \n",
+                        "\tcompatibility_weight=1, \n",
+                        "\tcompatibility_fn=<function Preference.__init__.<locals>.<lambda> at 0x000001E0B5677BE0>\n",
+                        ")), 'Height': Attribute(name=Height, value=167, preference=NumericalPreference(\n",
+                        "\tpreferred_range=[172, 217], \n",
+                        "\tpreferred_score=1.25, \n",
+                        "\tnonpreferred_score=0.25, \n",
+                        "\tdistance_sensitive=True, \n",
+                        "\tcompatibility_weight=1.5, \n",
+                        "\tcompatibility_fn=<function Preference.__init__.<locals>.<lambda> at 0x000001E0B5677910>\n",
+                        ")), 'BMI': Attribute(name=BMI, value=3, preference=NumericalPreference(\n",
+                        "\tpreferred_range=[2, 4], \n",
+                        "\tpreferred_score=1.25, \n",
+                        "\tnonpreferred_score=0.25, \n",
+                        "\tdistance_sensitive=True, \n",
+                        "\tcompatibility_weight=1, \n",
+                        "\tcompatibility_fn=<function Preference.__init__.<locals>.<lambda> at 0x000001E0B56779A0>\n",
+                        "))}\n",
+                        "Agent's attractiveness: 2.9165048462066303\n",
+                        "Agent's estimated attractiveness: 3.315649708042419\n",
+                        "Agent's match count: 18\n",
+                        "Agent's happiness: 64.89399280009835\n"
+                    ]
+                }
+            ],
+            "source": [
+                "reported_agent = matcher.agents[10]\n",
+                "\n",
+                "print(\"Agent's reported attributes:\", reported_agent.reported_attributes)\n",
+                "print(\"Agent's attractiveness:\", reported_agent.attractiveness)\n",
+                "print(\"Agent's estimated attractiveness:\", reported_agent.estimated_attractiveness)\n",
+                "print(\"Agent's match count:\", reported_agent.match_count)\n",
+                "print(\"Agent's happiness:\", reported_agent.happiness)"
+            ]
+        },
+        {
+            "cell_type": "markdown",
+            "id": "7940dc51-e4c7-40c0-8a02-a820dafd72b8",
+            "metadata": {},
+            "source": [
+                "You can put all agents' attributes and results into a pandas DataFrame for analysis. Also, if logging was enabled before the simulation, it is possible to retrieve the past states of an agent as follows:"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": 15,
+            "id": "1eb30944",
+            "metadata": {},
+            "outputs": [
+                {
+                    "name": "stdout",
+                    "output_type": "stream",
+                    "text": [
+                        "{'match_count': {1: 13, 2: 15, 3: 17, 4: 18, 5: 18, 6: 18, 7: 18, 8: 18, 9: 18, 10: 18}, 'happiness': {1: 47.582190551992035, 2: 54.635216687050644, 3: 61.53679236021338, 4: 64.89399280009835, 5: 64.89399280009835, 6: 64.89399280009835, 7: 64.89399280009835, 8: 64.89399280009835, 9: 64.89399280009835, 10: 64.89399280009835}}\n",
+                        "{'happiness': 61.53679236021338}\n"
+                    ]
+                }
+            ],
+            "source": [
+                "# Retrieves all rounds and variables (match_count and happiness):\n",
+                "print(reported_agent.get_logs())\n",
+                "\n",
+                "# This retrieves the happiness value for the third round's ending. Log ID is 1-based and\n",
+                "# indicates the round number.\n",
+                "print(reported_agent.get_logs(log_id=3, variables=[\"happiness\"]))"
+            ]
+        },
+        {
+            "cell_type": "markdown",
+            "id": "ddb4b2f0",
+            "metadata": {},
+            "source": [
+                "### Behind the curtain"
+            ]
+        },
+        {
+            "cell_type": "markdown",
+            "id": "47e09804",
+            "metadata": {},
+            "source": [
+                "When you run a simulation round as shown above using `PreferentialAgentMatcher.run_new_round()`, the most important operations that take place in the background are as follows:\n",
+                "\n",
+                "*   `PreferentialAgentMatcher` increments its round counter and prepares itself for a new round.\n",
+                "*   If recalculation is enabled, `PreferentialAgentMatcher` recalculates the compatibilities and therefore recommendation priorities for agents.\n",
+                "*   For each `Agent` object in the matcher:\n",
+                "    *   `Agent` is informed about the new round.\n",
+                "    *   Fresh candidates that were not previously evaluated by the agent are identified.\n",
+                "    *   These new candidates' public details (ID, attractiveness, reported attributes) are provided to the agent.\n",
+                "    *   Agent uses their strategy object to like or pass each candidate in the order they were provided. These likes and passes are recorded.\n",
+                "* Round likes and passes are processed. New reciprocal likes are detected (it is possible for an agent to like another agent and get liked many rounds later) and the agents are informed.\n",
+                "*   If logging is enabled, all agents' states are logged."
+            ]
+        }
+    ],
+    "metadata": {
+        "kernelspec": {
+            "display_name": "Python 3 (ipykernel)",
+            "language": "python",
+            "name": "python3"
+        },
+        "language_info": {
+            "codemirror_mode": {
+                "name": "ipython",
+                "version": 3
+            },
+            "file_extension": ".py",
+            "mimetype": "text/x-python",
+            "name": "python",
+            "nbconvert_exporter": "python",
+            "pygments_lexer": "ipython3",
+            "version": "3.10.7"
+        }
+    },
+    "nbformat": 4,
+    "nbformat_minor": 5
+}

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -11,6 +11,7 @@ Welcome to catfish-sim's documentation!
    :caption: Contents:
 
    modules
+   tutorials
 
 
 

--- a/docs/requirements-doc.txt
+++ b/docs/requirements-doc.txt
@@ -1,2 +1,6 @@
 Sphinx==7.3.7
 sphinx-rtd-theme
+nbsphinx==0.9.4
+nbconvert==7.0.0
+ipython==8.23.0
+Pygments==2.17.2

--- a/docs/tutorials.rst
+++ b/docs/tutorials.rst
@@ -1,0 +1,9 @@
+.. _tutorials:
+
+Tutorials
+=========
+
+.. toctree::
+   :maxdepth: 2
+
+   examples/getting_started

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "catfish-sim"
-version = "0.1.1"
+version = "0.2.0"
 authors = [{ name = "Oz Kilic", email = "ozgunozankilic@gmail.com" }]
 description = "A multiagent online dating simulation framework."
 license = { file = "LICENSE" }

--- a/tests/test_dealbreaker.py
+++ b/tests/test_dealbreaker.py
@@ -161,6 +161,83 @@ def test_matchmaker():
     assert len(twosided_preferential_matcher.recommendation_priority[0]) == 0
     assert len(twosided_preferential_matcher.recommendation_priority[1]) == 0
 
+    inconsiderate_ranked_matcher = matchers.RankedAgentMatcher(
+        agents=[male_agent, female_agent],
+        recommendation_limit=100,
+        compatibility_calculator=compatibility.CompatibilityCalculator(),
+        consider_dealbreakers=False,
+    )
+
+    # The matcher does not cares about anyone's deal-breakers, so both agents are deemed compatible.
+    assert (
+        len(
+            inconsiderate_ranked_matcher.get_available_candidates(
+                inconsiderate_ranked_matcher.agents[0]
+            )
+        )
+        == 1
+    )
+    assert (
+        len(
+            inconsiderate_ranked_matcher.get_available_candidates(
+                inconsiderate_ranked_matcher.agents[1]
+            )
+        )
+        == 1
+    )
+
+    selfish_ranked_matcher = matchers.RankedAgentMatcher(
+        agents=[male_agent, female_agent],
+        recommendation_limit=100,
+        compatibility_calculator=compatibility.CompatibilityCalculator(),
+        consider_dealbreakers=True,
+        dealbreaker_judger_weight=1,
+    )
+
+    # The matcher only cares about the judger's viewpoint, so the male has a candidate while the female does not.
+    assert (
+        len(
+            selfish_ranked_matcher.get_available_candidates(
+                selfish_ranked_matcher.agents[0]
+            )
+        )
+        == 1
+    )
+    assert (
+        len(
+            selfish_ranked_matcher.get_available_candidates(
+                selfish_ranked_matcher.agents[1]
+            )
+        )
+        == 0
+    )
+
+    twosided_ranked_matcher = matchers.RankedAgentMatcher(
+        agents=[male_agent, female_agent],
+        recommendation_limit=100,
+        compatibility_calculator=compatibility.CompatibilityCalculator(),
+        consider_dealbreakers=True,
+        dealbreaker_judger_weight=0.5,
+    )
+
+    # The matcher cares about both viewpoints, so no agent has a candidate, as one side of the match is incompatible.
+    assert (
+        len(
+            twosided_ranked_matcher.get_available_candidates(
+                twosided_ranked_matcher.agents[0]
+            )
+        )
+        == 0
+    )
+    assert (
+        len(
+            twosided_ranked_matcher.get_available_candidates(
+                twosided_ranked_matcher.agents[1]
+            )
+        )
+        == 0
+    )
+
 
 def test_preference():
     """Ensures that a non-preferred value with strict misrepresentation affects the perceived compatibility scores."""


### PR DESCRIPTION
## [0.2.0] - 2024-05-19

### Added

- `DictBasedPreference`: A new preference class that can be used to exactly specify the compatibility score for all attribute values. While `CategoricalPreference` class was able to handle value-compatibility dictionaries, `DictBasedPreference` allows setting a default compatibility score for attribute values that are not specified, and its parameters are more intuitive to use with a dictionary.
- A "getting started" tutorial in the documentation.
- Missing parameter explanations in the docstrings.
- LLCP2022 dataset ranges for age, height, and BMI for ease of use.

### Changed

- Added deal-breaker consideration for `RankedAgentMatcher`: It is now possible to consider one-sided or two-sided deal-breakers while making recommendations.
- Other minor code and documentation improvements, typo fixes.

### Developer notes

- scikit-learn was intended to be dropped from the dependencies. However, due to self-written min-max scaling functions not yielding the exact same results with the one imported from scikit-learn, it was decided to keep scikit-learn.
- `CategoricalPreference` still has the functionality to handle compatibility dictionaries, but this feature may be deprecated in later versions, as there is now a specific class for dictionaries, `DictBasedPreference`.