### PR TITLE
Add lxml to doc requirements

### DIFF
--- a/docs/requirements-doc.txt
+++ b/docs/requirements-doc.txt
@@ -5,3 +5,4 @@ nbsphinx==0.9.4
 nbconvert==7.0.0
 ipython==8.23.0
 Pygments==2.17.2
+lxml==4.9.1


### PR DESCRIPTION
Local documentation files were fine, but Read the Docs gives the following error:

Traceback (most recent call last):
  File "/home/docs/checkouts/readthedocs.org/user_builds/catfish-sim/envs/latest/lib/python3.10/site-packages/sphinx/cmd/build.py", line 332, in build_main
    app = Sphinx(args.sourcedir, args.confdir, args.outputdir,
  File "/home/docs/checkouts/readthedocs.org/user_builds/catfish-sim/envs/latest/lib/python3.10/site-packages/sphinx/application.py", line 229, in __init__
    self.setup_extension(extension)
  File "/home/docs/checkouts/readthedocs.org/user_builds/catfish-sim/envs/latest/lib/python3.10/site-packages/sphinx/application.py", line 402, in setup_extension
    self.registry.load_extension(self, extname)
  File "/home/docs/checkouts/readthedocs.org/user_builds/catfish-sim/envs/latest/lib/python3.10/site-packages/sphinx/registry.py", line 456, in load_extension
    raise ExtensionError(__('Could not import extension %s') % extname,
sphinx.errors.ExtensionError: Could not import extension nbsphinx (exception: lxml.html.clean module is now a separate project lxml_html_clean. Install lxml[html_clean] or lxml_html_clean directly.)

Extension error:
Could not import extension nbsphinx (exception: lxml.html.clean module is now a separate project lxml_html_clean. Install lxml[html_clean] or lxml_html_clean directly.)